### PR TITLE
Add security headers to webhook secret rotation responses

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "repositories": [
         {
             "type": "vcs",
-            "url": "https://github.com/host-uk/core"
+            "url": "https://github.com/host-uk/core-php"
         }
     ],
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -3,12 +3,6 @@
     "description": "REST API module for Core PHP framework",
     "keywords": ["laravel", "api", "rest", "json"],
     "license": "EUPL-1.2",
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/host-uk/core-php"
-        }
-    ],
     "require": {
         "php": "^8.2",
         "host-uk/core": "@dev",

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,12 @@
     "description": "REST API module for Core PHP framework",
     "keywords": ["laravel", "api", "rest", "json"],
     "license": "EUPL-1.2",
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/host-uk/core"
+        }
+    ],
     "require": {
         "php": "^8.2",
         "host-uk/core": "@dev",

--- a/src/Api/Controllers/Api/WebhookSecretController.php
+++ b/src/Api/Controllers/Api/WebhookSecretController.php
@@ -22,6 +22,9 @@ class WebhookSecretController extends Controller
 
     /**
      * Rotate a social webhook secret.
+     *
+     * Note: The new secret is only returned once in this response and cannot
+     * be retrieved later. The user must store it securely immediately.
      */
     public function rotateSocialSecret(Request $request, string $uuid): JsonResponse
     {
@@ -55,11 +58,17 @@ class WebhookSecretController extends Controller
                 'secret' => $newSecret,
                 'status' => $this->rotationService->getSecretStatus($webhook->fresh()),
             ],
-        ]);
+        ])
+            ->header('Cache-Control', 'no-store, no-cache, must-revalidate, private')
+            ->header('Pragma', 'no-cache')
+            ->header('X-Sensitive-Response', 'true');
     }
 
     /**
      * Rotate a content webhook endpoint secret.
+     *
+     * Note: The new secret is only returned once in this response and cannot
+     * be retrieved later. The user must store it securely immediately.
      */
     public function rotateContentSecret(Request $request, string $uuid): JsonResponse
     {
@@ -93,7 +102,10 @@ class WebhookSecretController extends Controller
                 'secret' => $newSecret,
                 'status' => $this->rotationService->getSecretStatus($endpoint->fresh()),
             ],
-        ]);
+        ])
+            ->header('Cache-Control', 'no-store, no-cache, must-revalidate, private')
+            ->header('Pragma', 'no-cache')
+            ->header('X-Sensitive-Response', 'true');
     }
 
     /**


### PR DESCRIPTION
The `WebhookSecretController::rotateSocialSecret()` and `rotateContentSecret()` methods now include security headers to prevent sensitive secrets from being cached by browsers or proxies, or logged by intermediate systems.

Specifically, the following headers were added:
- `Cache-Control: no-store, no-cache, must-revalidate, private`
- `Pragma: no-cache`
- `X-Sensitive-Response: true`

Additionally, the docblocks for these methods have been updated to reflect that the secret is only shown once upon rotation.

Fixes #7

---
*PR created automatically by Jules for task [15342349361798186631](https://jules.google.com/task/15342349361798186631) started by @Snider*